### PR TITLE
Remove backreferences from message regex.

### DIFF
--- a/github/.gitignore
+++ b/github/.gitignore
@@ -1,4 +1,4 @@
 .DS_store/
-.gasp.json
+.clasp.json
 dist
 node_modules/

--- a/github/src/MessageUtils.js
+++ b/github/src/MessageUtils.js
@@ -58,7 +58,7 @@ function extractGitHubLinks(messageBodies) {
  * @return {GitHubLink[]} extracted link information, empty array if none found.
  */
 function extractGitHubLinksFromText_(text, appendTo) {
-  var re = /https:\/\/github.com\/(.+?)(?<!<)\/(?!>)(.+?)(?<!<)\/(?!>)(issues|pull)(?<!<)\/(?!>)(\d+)/gi;
+  var re = /https:\/\/github.com\/([^\/]+?)\/([^\/]+?)\/(issues|pull)\/(\d+)/gi;
   while ((match = re.exec(text)) !== null) {
     var type = stripHtmlTags(match[3]);
     appendTo.push({


### PR DESCRIPTION
They aren't supported in JavaScript. Reverted back to the previous regex, which seems to work fine, even with <wbr> tags inserted. Fixes #20.